### PR TITLE
fix variable length array of non-POD element type error

### DIFF
--- a/c_src/erlang_v8.cc
+++ b/c_src/erlang_v8.cc
@@ -166,7 +166,7 @@ void call(Isolate* isolate, string input) {
                         "args")));
 
     int len = args->Length();
-    Handle<Value> argz[len];
+    Handle<Value> *argz = new Handle<Value>[len];
 
     // debug(static_cast<ostringstream*>( &(ostringstream() << len) )->str());
     for (int i = 0; i < len; i++) { 


### PR DESCRIPTION
fix #1 

$ make tests
...
TEST INFO: 1 test(s), 15 case(s) in 1 suite(s)

  Testing strange.erlang-v8.port_SUITE: Starting test, 15 test cases
  Testing strange.erlang-v8.port_SUITE: TEST COMPLETE, 15 ok, 0 failed
  of 15 test cases

  Updating
  /Users/babie/src/github.com/babie/erlang-v8/logs/index.html... done
  Updating
  /Users/babie/src/github.com/babie/erlang-v8/logs/all_runs.html...
  done

   GEN    eunit
     There were no tests to run.
