### PR TITLE
Add module support

### DIFF
--- a/c_src/Makefile
+++ b/c_src/Makefile
@@ -10,16 +10,12 @@ ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 LIB_DIR := $(ROOT_DIR)/../lib
 PRIV_DIR := $(ROOT_DIR)/../priv
 
-DEPOT_DIR := $(LIB_DIR)/depot_tools
-
-V8_VERSION := "5.9.211.33"
-V8_DIR := $(LIB_DIR)/v8
-V8_LIB := $(V8_DIR)/out.gn/$(BUILD_ARCH).release/obj
-
 TARGET_BIN := $(PRIV_DIR)/erlang_v8
 TARGET_SRC := erlang_v8.cc report.cc vm.cc
 
-PATH := $(PATH):$(DEPOT_DIR)
+V8_DIR := /usr/include/nodejs/deps/v8
+
+PATH := $(PATH)
 SHELL := /bin/bash
 
 .PHONY: all v8 clean distclean local-clean local-distclean
@@ -36,7 +32,7 @@ local-clean:
 local-distclean: local-clean
 	rm -rf $(LIB_DIR)
 
-v8: $(TARGET_BIN) $(PRIV_DIR)/natives_blob.bin $(PRIV_DIR)/snapshot_blob.bin $(PRIV_DIR)/icudtl.dat
+v8: $(TARGET_BIN)
 
 $(LIB_DIR):
 	mkdir -p $(LIB_DIR)
@@ -44,34 +40,7 @@ $(LIB_DIR):
 $(PRIV_DIR):
 	mkdir -p $(PRIV_DIR)
 
-$(DEPOT_DIR): $(LIB_DIR)
-ifeq ($(wildcard $(DEPOT_DIR)),)
-	cd $(LIB_DIR) && git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git;
-endif
-
-$(V8_DIR): $(LIB_DIR) $(DEPOT_DIR)
-ifeq ($(wildcard $(V8_DIR)),)
-	@echo $(LIB_DIR)
-	@cd $(LIB_DIR) && $(DEPOT_DIR)/fetch v8
-endif
-
-$(V8_LIB)/libv8_base.a: $(V8_DIR)
-	cd $(LIB_DIR) && gclient sync --revision $(V8_VERSION)
-	cd $(V8_DIR) && tools/dev/v8gen.py -vv $(BUILD_ARCH).release
-	cd $(V8_DIR) && gn gen "--args=is_component_build = false is_debug = false v8_static_library = true target_cpu = \"$(BUILD_ARCH)\"" out.gn/$(BUILD_ARCH).release
-	cd $(V8_DIR) && $(DEPOT_DIR)/ninja -C out.gn/$(BUILD_ARCH).release
-	@touch $@
-
-$(PRIV_DIR)/natives_blob.bin: $(V8_LIB)/libv8_base.a
-	cp $(V8_LIB)/../natives_blob.bin $(PRIV_DIR)
-
-$(PRIV_DIR)/snapshot_blob.bin: $(V8_LIB)/libv8_base.a
-	cp $(V8_LIB)/../snapshot_blob.bin $(PRIV_DIR)
-
-$(PRIV_DIR)/icudtl.dat: $(V8_LIB)/libv8_base.a
-	cp $(V8_LIB)/../icudtl.dat $(PRIV_DIR)
-
-$(TARGET_BIN): $(PRIV_DIR) $(TARGET_SRC) $(V8_LIB)/libv8_base.a
+$(TARGET_BIN): $(PRIV_DIR) $(TARGET_SRC)
 ifeq ($(OS),Darwin)
 	# We need to link libstdc++ as XCode defaults to libc++, and use slightly
 	# different flags, on OS X. The following assumes Mavericks, XCode and
@@ -82,18 +51,14 @@ ifeq ($(OS),Darwin)
 		-stdlib=libstdc++ \
 		-std=c++0x \
 		-o $(TARGET_BIN) \
-		$(V8_LIB)/libv8_{base,libbase,external_snapshot,libplatform,libsampler}.a \
-		$(V8_LIB)/libicu{uc,i18n}.a \
-		-lpthread
+		-lv8 -lpthread
 else
 	g++ \
 		-I$(V8_DIR)/include \
 		$(TARGET_SRC) \
 		-o $(TARGET_BIN) \
 		-Wno-unused-variable \
-		-Wl,--start-group \
-		$(V8_LIB)/{libv8_{base,libbase,external_snapshot,libplatform,libsampler},third_party/icu/libicu{uc,i18n},src/inspector/libinspector}.a \
-		-Wl,--end-group \
+		-lv8 \
 		-lrt \
 		-ldl \
 		-pthread \

--- a/c_src/debug.h
+++ b/c_src/debug.h
@@ -1,7 +1,7 @@
 #ifndef DEBUG_H
 #define DEBUG_H
 
-#define DEBUG 0
+#define DEBUG 1
 
 #define FTRACE(fmt, ...) \
     do { if (DEBUG) fprintf(stderr, "%s:%d:%s(): " fmt, __FILE__, \

--- a/c_src/erlang_v8.cc
+++ b/c_src/erlang_v8.cc
@@ -107,11 +107,15 @@ bool CommandLoop(VM& vm) {
                 FTRACE("Ignoring reset: %i\n", packet.ref);
                 // reset = true;
                 break;
+	    case OP_COMPILE_MODULE:
+		FTRACE("Compiling module: %i\n", packet.ref);
+		vm.CompileModule(&packet);
+		break;
         }
         vm.PumpMessageLoop();
         packet = (const Packet){ 0 };
     }
-    Isolate::GetCurrent()->ContextDisposedNotification(); 
+    Isolate::GetCurrent()->ContextDisposedNotification();
     return reset;
 }
 

--- a/c_src/packet.h
+++ b/c_src/packet.h
@@ -11,6 +11,7 @@ const uint8_t OP_CALL = 2;
 const uint8_t OP_CREATE_CONTEXT = 3;
 const uint8_t OP_DESTROY_CONTEXT = 4;
 const uint8_t OP_RESET_VM = 5;
+const uint8_t OP_COMPILE_MODULE = 6;
 
 struct Packet {
     uint8_t op;

--- a/c_src/vm.cc
+++ b/c_src/vm.cc
@@ -24,7 +24,7 @@ struct TimeoutHandlerArgs {
 void* TimeoutHandler(void *arg) {
     struct TimeoutHandlerArgs *args = (struct TimeoutHandlerArgs*)arg;
 
-    FTRACE("Timeout handler started: %i\n", args->timeout);
+    FTRACE("Timeout handler started: %li\n", args->timeout);
     usleep(args->timeout * 1000);
     TRACE("Timeout expired. Terminating execution.\n");
 
@@ -83,7 +83,8 @@ void VM::PumpMessageLoop() {
 }
 
 void VM::TerminateExecution() {
-    v8::V8::TerminateExecution(isolate);
+    // v8::V8::TerminateExecution(isolate); Was deprecated, is now removed, the isolate
+    //                                      member function does the same.
     isolate->TerminateExecution();
     FTRACE("Isolate terminated: %i\n", 10);
 }
@@ -193,7 +194,7 @@ void VM::Call(Packet* packet) {
         int len = raw_args->Length();
         Local<Value> *args = new Local<Value>[len];
 
-        for (int i = 0; i < len; i++) { 
+        for (int i = 0; i < len; i++) {
             args[i] = raw_args->Get(i);
         }
 

--- a/c_src/vm.cc
+++ b/c_src/vm.cc
@@ -174,10 +174,29 @@ MaybeLocal<Module> ResolveCallback(Local<Context> context,
 //  if (specifier->StrictEquals(v8_str("./dep1.js"))) {
 //    return dep1;
 //  } else {
+    TRACE("Resolve callback called back!\n");
     Isolate *isolate = context->GetIsolate();
     isolate->ThrowException(String::NewFromUtf8(isolate, "boom"));
     return MaybeLocal<Module>();
 //  }
+}
+
+const char *to_c(Isolate *i, Local<Value> s) {
+    TryCatch try_catch(i);
+    v8::String::Utf8Value uv(i, s);
+    if (uv.length() == 0) {
+	TRACE("Could not convert");
+	if (try_catch.HasCaught()) {
+	    TRACE("Exception caught");
+	    Local<String> msg = try_catch.Message()->Get();
+	    TRACE("TODO stringify msg if you hit this...");
+	}
+	return "<oops>";
+    } else {
+	std::string stds = std::string(*uv);
+	FTRACE("to_c(...) -> len %d, v <%s>\n", uv.length(), stds.c_str());
+	return stds.c_str();
+    }
 }
 
 void VM::CompileModule(Packet* packet) {
@@ -189,40 +208,60 @@ void VM::CompileModule(Packet* packet) {
 
     if (context.IsEmpty()) {
         Local<String> tt = String::NewFromUtf8(isolate, "empty context");
+	FTRACE("Empty context %i\n", packet->ref);
         Report(isolate, tt, OP_INVALID_CONTEXT);
     } else {
-        Context::Scope context_scope(context);
-
         string input = packet->data;
 
+	FTRACE("Unpacking args from [%s]\n", input.c_str());
         Local<String> json_data = String::NewFromUtf8(isolate, input.c_str());
+	FTRACE("Click 1 from [%s]\n", to_c(isolate, json_data));
         Local<Object> instructions = Local<Object>::Cast(
             JSON::Parse(context, json_data).ToLocalChecked()
         );
+	FTRACE("Click 2 %s\n", to_c(isolate, instructions->ToString(context).ToLocalChecked()));
 
 	Local<String> name_key = String::NewFromUtf8(isolate, "name");
+	FTRACE("Click 3, name_key = [%s]\n", to_c(isolate, name_key));
         Local<String> source_key = String::NewFromUtf8(isolate, "source");
+	FTRACE("Click 4, source_key = [%s]\n", to_c(isolate, source_key));
 
-	Local<String> name = instructions->Get(name)->ToString();
-        Local<String> source_code = instructions->Get(source_key)->ToString();
+	Local<String> name = instructions->Get(name_key)->ToString();
+	FTRACE("Click 5, name is [%s]\n", to_c(isolate, name));
+        //Local<String> source_code = instructions->Get(source_key)->ToString();
+	Local<String> source_code = String::NewFromUtf8(isolate, "export function sum(x, y) { return x + y }");
+	FTRACE("Click 6, code is [%s]\n", to_c(isolate, source_code));
+	FTRACE("Click 6, code is [%s]\n", to_c(isolate, source_code->ToDetailString(context).ToLocalChecked()));
 
 	ScriptOrigin origin = ModuleOrigin(name, isolate);
 	ScriptCompiler::Source source(source_code, origin);
-	Local<Module> module = ScriptCompiler::CompileModule(isolate, &source).ToLocalChecked();
+	TRACE("Compile module\n");
+	MaybeLocal<Module> maybe_module = ScriptCompiler::CompileModule(isolate, &source);
+	TRACE("Checking status\n");
 
-        if (module->GetStatus() == v8::Module::kErrored) {
+	if (maybe_module.IsEmpty()) {
+	    TRACE("Module is empty\n");
             assert(try_catch.HasCaught());
             ReportException(isolate, &try_catch);
         } else {
-
-	    Maybe<bool> result = module->InstantiateModule(context, ResolveCallback);
-	    if (result.IsNothing() || module->GetStatus() == v8::Module::kErrored) {
+	    Local<Module> module = maybe_module.ToLocalChecked();
+	    if (module->GetStatus() == v8::Module::kErrored) {
+		TRACE("Bad status\n");
 		assert(try_catch.HasCaught());
 		ReportException(isolate, &try_catch);
 	    } else {
-		ReportOK(isolate, name);
+		TRACE("Good status, instantiating module\n");
+		Maybe<bool> result = module->InstantiateModule(context, ResolveCallback);
+		if (result.IsNothing() || module->GetStatus() == v8::Module::kErrored) {
+		    TRACE("Instantiate no workies\n");
+		    assert(try_catch.HasCaught());
+		    ReportException(isolate, &try_catch);
+		} else {
+		    TRACE("Instantiate workies\n");
+		    ReportOK(isolate, name);
+		}
 	    }
-        }
+	}
     }
 }
 

--- a/c_src/vm.h
+++ b/c_src/vm.h
@@ -20,7 +20,7 @@ class VM {
 
         void Eval(Packet *packet);
         void Call(Packet *packet);
-
+        void CompileModule(Packet *packet);
         void PumpMessageLoop();
         void TerminateExecution();
 

--- a/src/erlang_v8.app.src
+++ b/src/erlang_v8.app.src
@@ -1,7 +1,7 @@
 {application, erlang_v8,
  [
-  {description, ""},
-  {vsn, "1"},
+  {description, "V8 Bindings for Erlang"},
+  {vsn, "2"},
   {registered, []},
   {modules, []},
   {applications, [

--- a/src/erlang_v8.erl
+++ b/src/erlang_v8.erl
@@ -13,6 +13,7 @@
 -export([eval/4]).
 -export([call/4]).
 -export([call/5]).
+-export([compile_module/4]).
 
 start_vm() ->
     start_vm([]).
@@ -43,3 +44,6 @@ call(Pid, Context, FunctionName, Args) ->
 
 call(Pid, Context, FunctionName, Args, Timeout) ->
     erlang_v8_vm:call(Pid, Context, FunctionName, Args, Timeout).
+
+compile_module(Pid, Context, Name, Source) ->
+    erlang_v8_vm:compile_module(Pid, Context, Name, Source).

--- a/src/erlang_v8_vm.erl
+++ b/src/erlang_v8_vm.erl
@@ -112,6 +112,7 @@ handle_call({eval, Context, Source, Timeout}, _From,
 handle_call({compile_module, Context, Name, Source}, _From,
             #state{port = Port, max_source_size = MaxSourceSize} = State) ->
     Instructions = jsx:encode(#{ name => Name, source => Source }),
+    io:fwrite("About to compile module ~w, insns=~w~n", [Name, Instructions]),
     handle_response(send_to_port(Port, ?OP_COMPILE_MODULE, Context, Instructions,
                                  MaxSourceSize), State);
 
@@ -160,6 +161,7 @@ handle_cast(_Message, State) ->
 
 handle_info({'DOWN', MRef, process, _Pid, _Reason},
             #state{table = Table, port = Port} = State) ->
+    io:fwrite("Down, state=~w~n", [State]),
     [[Context]] = ets:match(Table, {'$1', MRef}),
     true = ets:delete(Table, Context),
     send_to_port(Port, ?OP_DESTROY_CONTEXT, Context),

--- a/test/port_SUITE.erl
+++ b/test/port_SUITE.erl
@@ -8,6 +8,7 @@
 
 -export([eval/1]).
 -export([call/1]).
+-export([compile_module/1]).
 -export([return_type/1]).
 -export([nested_return_type/1]).
 -export([errors/1]).
@@ -25,20 +26,21 @@
 
 all() ->
     [
-        eval,
-        call,
-        return_type,
-        timeout,
-        nested_return_type,
-        errors,
-        contexts,
-        init_from_source,
-        init_from_file,
-        multiple_vms,
-        performance,
-        big_input,
-        dead_proc,
-        escaped_control_characters
+        % eval,
+        % call,
+        compile_module
+        % return_type,
+        % timeout,
+        % nested_return_type,
+        % errors,
+        % contexts,
+        % init_from_source,
+        % init_from_file,
+        % multiple_vms,
+        % performance,
+        % big_input,
+        % dead_proc,
+        % escaped_control_characters
     ].
 
 init_per_suite(Config) ->
@@ -68,7 +70,7 @@ call(_Config) ->
     {ok, P} = erlang_v8:start_vm(),
 
     {ok, Context} = erlang_v8:create_context(P),
-    
+
     {ok, undefined} = erlang_v8:eval(P, Context, <<"function sum(a, b) { return a + b; }">>),
     {ok, 3} = erlang_v8:call(P, Context, <<"sum">>, [1, 2]),
 
@@ -100,6 +102,20 @@ call(_Config) ->
 
     erlang_v8:stop_vm(P),
     ok.
+
+compile_module(_Config) ->
+    {ok, P} = erlang_v8:start_vm(),
+
+    {ok, Context} = erlang_v8:create_context(P),
+
+    ok = erlang_v8:compile_module(P, Context, <<"test.js">>,
+				  <<"export function sum(x, y) { return x + y }">>),
+
+    ok = erlang_v8:destroy_context(P, Context),
+
+    erlang_v8:stop_vm(P),
+    ok.
+
 
 return_type(_Config) ->
     {ok, P} = erlang_v8:start_vm(),
@@ -160,7 +176,7 @@ nested_return_type(_Config) ->
 
     erlang_v8:stop_vm(VM),
     ok.
- 
+
 errors(_Config) ->
     {ok, P} = erlang_v8:start_vm(),
 


### PR DESCRIPTION
The idea behind this is that we can use the standard `import` and `export` features of JS, plus - eventually - are able to 
define something like Erlang-level synthetic modules to cleanly export BEAM code to V8. 